### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bun.yml
+++ b/.github/workflows/bun.yml
@@ -1,4 +1,6 @@
 name: CI Pipeline via GitHub Actions
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/digitalservicebund/hack-jira-cfd/security/code-scanning/1](https://github.com/digitalservicebund/hack-jira-cfd/security/code-scanning/1)

To fix the problem, we should add a `permissions` block to the workflow or to the specific job inside `.github/workflows/bun.yml`. Since no steps in the shown job require anything beyond simply reading repository contents (they checkout source, install dependencies, lint, test, and dislay coverage), the minimal recommended permission is `contents: read`. The best way to fix, without changing logic, is to place a top-level `permissions` block in the workflow, which will apply to all jobs unless overridden. Insert the following after the `name:` (after line 1, before `on:`):

```yaml
permissions:
  contents: read
```

No package installs or code logic changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
